### PR TITLE
fix rst syntax error as follows:

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Return value
 	VOID
 Description
 	Parse the cookie string in string S. The parsed values are only guaranteed
-to exist within a single VCL function. Implicit clean() if run more than once.
+	to exist within a single VCL function. Implicit clean() if run more than once.
 Example
         ::
 


### PR DESCRIPTION
  rst2man README.rst vmod_cookie.3
  README.rst:58: (WARNING/2) Definition list ends without a blank line; unexpected unindent.
  README.rst:60: (ERROR/3) Unexpected indentation.
