### PR TITLE
fix warning treated as error, caused by using CFLAGS -Wall -Werror

### DIFF
--- a/src/vmod_cookie.c
+++ b/src/vmod_cookie.c
@@ -78,7 +78,7 @@ cobj_get(const struct vrt_ctx *ctx) {
 VCL_VOID
 vmod_parse(const struct vrt_ctx *ctx, VCL_STRING cookieheader) {
 	char tokendata[MAX_COOKIESTRING];
-	char *token, *tokstate, *key, *value, *sepindex;
+	char *token, *tokstate, *value, *sepindex;
 	char *dataptr = tokendata;
 	struct vmod_cookie *vcp = cobj_get(ctx);
 	CHECK_OBJ_NOTNULL(vcp, VMOD_COOKIE_MAGIC);


### PR DESCRIPTION
I came across this error while building varnish 4.0.0, having subtree-merged libvmod-cookie into the varnish tree; the latter uses CFLAGS -Wall -Werror by default.

Maybe there is a better way to handle this warning, but I just wanted to let you know about it.
