### PR TITLE
fixed the test for isset()

### DIFF
--- a/src/tests/07-isset.vtc
+++ b/src/tests/07-isset.vtc
@@ -21,10 +21,10 @@ varnish v1 -vcl+backend {
 		}
 
 		if (cookie.isset("non-existent")) {
-			set resp.http.X-foo = "nok";
+			set resp.http.X-bar = "nok";
 		}
 		else {
-			set resp.http.X-foo = "ok";
+			set resp.http.X-bar = "ok";
 		}
 	}
 } -start


### PR DESCRIPTION
The test performs a check of the isset() method on both an existing and a non-existing cookie.
Of course, a copy/paste was used, without correctly patching the variables names. The test now passes correctly.